### PR TITLE
change width, height htmlwidget args to be default NULL

### DIFF
--- a/pkg/R/datacomb.R
+++ b/pkg/R/datacomb.R
@@ -9,8 +9,7 @@
 #' @param rowLabel name of the column in \code{data}
 #'          that provides the row label
 #' @param width,height valid \code{CSS} size unit for the
-#'          width and height of the datacomb.  The default is
-#'          \code{100\%} to fill the entire viewing area.
+#'          width and height of the datacomb.
 #'
 #' @example ./inst/examples/examples.R
 #' @import htmlwidgets
@@ -18,7 +17,7 @@
 #' @export
 Datacomb <- function(
   data = NULL, columns = colnames(data), rowLabel = NULL,
-  width = '100%', height = '100%'
+  width = NULL, height = NULL
 ) {
 
   # try to be smart if row names are character

--- a/pkg/man/Datacomb.Rd
+++ b/pkg/man/Datacomb.Rd
@@ -5,7 +5,7 @@
 \title{Datacomb}
 \usage{
 Datacomb(data = NULL, columns = colnames(data), rowLabel = NULL,
-  width = "100\%", height = "100\%")
+  width = NULL, height = NULL)
 }
 \arguments{
 \item{data}{a data object of a class that can be converted into a
@@ -18,8 +18,7 @@ to use as dimensions}
 that provides the row label}
 
 \item{width,height}{valid \code{CSS} size unit for the
-         width and height of the datacomb.  The default is
-         \code{100\%} to fill the entire viewing area.}
+         width and height of the datacomb.}
 }
 \description{
 An interactive interface for viewing and combing through data frames.


### PR DESCRIPTION
Change the default `height` and `width` to `NULL` as the default in the `Datacomb` htmlwidget function will make sizing more consistent with expected htmlwidget behavior.  `100%` without an explicit size causes trouble in some browsers.  Eventually explore more opinionated `sizingPolicy` but for now this change should result in more robust behavior.